### PR TITLE
feat: use same list for both xdai & polygon

### DIFF
--- a/src/hooks/useTokenIcon.js
+++ b/src/hooks/useTokenIcon.js
@@ -17,11 +17,11 @@ async function getTokenLogo(network, address) {
     // if (network === SupportedNetwork.MAINNET) {
     //   tokenListURL = "https://tokens.coingecko.com/uniswap/all.json"; // coingecko list used for mainnet
     // }
-    if (network === SupportedNetwork.XDAI) {
-      tokenListURL = "https://tokens.honeyswap.org"; // honeyswap list used for xdai
-    } else {
-      tokenListURL =
-        "https://unpkg.com/quickswap-default-token-list@latest/build/quickswap-default.tokenlist.json";
+    if (
+      network === SupportedNetwork.XDAI ||
+      network === SupportedNetwork.MATIC
+    ) {
+      tokenListURL = "https://tokens.honeyswap.org"; // honeyswap list used for xdai and polygon
     }
     const response = await fetch(tokenListURL);
     if (!response.ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2778,8 +2778,6 @@ asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
-  dependencies:
-    safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
With our current Polygon deployment, we now need to support a token list for both networks. This PR updates the URL for Polygon.