### PR TITLE
Fix fee rates for pairs containing wETH on Polygon

### DIFF
--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -9,7 +9,10 @@ import {
 import { formattedNum, localNumber, getFeeRate } from "../../utils";
 
 import { TYPE } from "../../Theme";
-import { useNativeCurrencySymbol } from "../../contexts/Network";
+import {
+  useNativeCurrencySymbol,
+  useSelectedNetwork,
+} from "../../contexts/Network";
 
 import { useAllPairData } from "../../contexts/PairData";
 
@@ -33,6 +36,7 @@ export default function GlobalStats() {
   const { oneDayTxns, pairCount } = useGlobalData();
   const nativeCurrencySymbol = useNativeCurrencySymbol();
   const [nativeCurrencyPrice] = useNativeCurrencyPrice();
+  const selectedNetwork = useSelectedNetwork();
   const formattedNativeCurrencyPrice = nativeCurrencyPrice
     ? formattedNum(nativeCurrencyPrice, true)
     : "-";
@@ -43,7 +47,7 @@ export default function GlobalStats() {
   if (!allPair.length) oneDayFees = "";
   else {
     const unformattedOneDayFees = allPair
-      .map((pair) => +pair.oneDayVolumeUSD * getFeeRate(pair))
+      .map((pair) => +pair.oneDayVolumeUSD * getFeeRate(pair, selectedNetwork))
       .reduce((acum, current) => acum + current);
 
     oneDayFees = formattedNum(unformattedOneDayFees, true);

--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -6,13 +6,12 @@ import {
   useGlobalData,
   useNativeCurrencyPrice,
 } from "../../contexts/GlobalData";
-import { formattedNum, localNumber } from "../../utils";
+import { formattedNum, localNumber, getFeeRate } from "../../utils";
 
 import { TYPE } from "../../Theme";
 import { useNativeCurrencySymbol } from "../../contexts/Network";
 
 import { useAllPairData } from "../../contexts/PairData";
-import { getAddress } from "ethers/utils";
 
 const Header = styled.div`
   width: 100%;
@@ -38,19 +37,13 @@ export default function GlobalStats() {
     ? formattedNum(nativeCurrencyPrice, true)
     : "-";
 
-  const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
   const allPair = Object.values(useAllPairData());
   let oneDayFees;
 
   if (!allPair.length) oneDayFees = "";
   else {
     const unformattedOneDayFees = allPair
-      .map((pair) =>
-        getAddress(pair.token0.id) === wethContract ||
-        getAddress(pair.token1.id) === wethContract
-          ? +pair.oneDayVolumeUSD * 0.00125
-          : +pair.oneDayVolumeUSD * 0.0025
-      )
+      .map((pair) => +pair.oneDayVolumeUSD * getFeeRate(pair))
       .reduce((acum, current) => acum + current);
 
     oneDayFees = formattedNum(unformattedOneDayFees, true);

--- a/src/components/GlobalStats/index.js
+++ b/src/components/GlobalStats/index.js
@@ -11,6 +11,9 @@ import { formattedNum, localNumber } from "../../utils";
 import { TYPE } from "../../Theme";
 import { useNativeCurrencySymbol } from "../../contexts/Network";
 
+import { useAllPairData } from "../../contexts/PairData";
+import { getAddress } from "ethers/utils";
+
 const Header = styled.div`
   width: 100%;
   position: sticky;
@@ -28,15 +31,30 @@ export default function GlobalStats() {
   const below400 = useMedia("(max-width: 400px)");
   const below816 = useMedia("(max-width: 816px)");
 
-  const { oneDayVolumeUSD, oneDayTxns, pairCount } = useGlobalData();
+  const { oneDayTxns, pairCount } = useGlobalData();
   const nativeCurrencySymbol = useNativeCurrencySymbol();
   const [nativeCurrencyPrice] = useNativeCurrencyPrice();
   const formattedNativeCurrencyPrice = nativeCurrencyPrice
     ? formattedNum(nativeCurrencyPrice, true)
     : "-";
-  const oneDayFees = oneDayVolumeUSD
-    ? formattedNum(oneDayVolumeUSD * 0.0025, true)
-    : "";
+
+  const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
+  const allPair = Object.values(useAllPairData());
+  let oneDayFees;
+
+  if (!allPair.length) oneDayFees = "";
+  else {
+    const unformattedOneDayFees = allPair
+      .map((pair) =>
+        getAddress(pair.token0.id) === wethContract ||
+        getAddress(pair.token1.id) === wethContract
+          ? +pair.oneDayVolumeUSD * 0.00125
+          : +pair.oneDayVolumeUSD * 0.0025
+      )
+      .reduce((acum, current) => acum + current);
+
+    oneDayFees = formattedNum(unformattedOneDayFees, true);
+  }
 
   return (
     <Header>

--- a/src/components/PairList/index.js
+++ b/src/components/PairList/index.js
@@ -17,6 +17,7 @@ import { TYPE } from "../../Theme";
 import {
   useNativeCurrencySymbol,
   useNativeCurrencyWrapper,
+  useSelectedNetwork
 } from "../../contexts/Network";
 
 dayjs.extend(utc);
@@ -135,6 +136,7 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
 
   const nativeCurrency = useNativeCurrencySymbol();
   const nativeCurrencyWrapper = useNativeCurrencyWrapper();
+  const selectedNetwork = useSelectedNetwork();
 
   useEffect(() => {
     setMaxPage(1); // edit this to do modular
@@ -159,7 +161,7 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
     if (pairData && pairData.token0 && pairData.token1) {
       const liquidity = formattedNum(pairData.reserveUSD, true);
       const volume = formattedNum(pairData.oneDayVolumeUSD, true);
-      const feeRate = getFeeRate(pairData);
+      const feeRate = getFeeRate(pairData, selectedNetwork);
       const apy = formattedPercent(
         (pairData.oneDayVolumeUSD * feeRate * 365 * 100) / pairData.reserveUSD
       );
@@ -229,8 +231,8 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
         const pairA = pairs[addressA];
         const pairB = pairs[addressB];
 
-        const feeRateA = getFeeRate(pairA);
-        const feeRateB = getFeeRate(pairB);
+        const feeRateA = getFeeRate(pairA, selectedNetwork);
+        const feeRateB = getFeeRate(pairB, selectedNetwork);
 
         if (sortedColumn === SORT_FIELD.APY) {
           const apy0 =

--- a/src/components/PairList/index.js
+++ b/src/components/PairList/index.js
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { CustomLink } from "../Link";
 import { Divider } from "../../components";
 import { withRouter } from "react-router-dom";
-import { formattedNum, formattedPercent } from "../../utils";
+import { formattedNum, formattedPercent, getFeeRate } from "../../utils";
 import DoubleTokenLogo from "../DoubleLogo";
 import FormattedName from "../FormattedName";
 import QuestionHelper from "../QuestionHelper";
@@ -159,8 +159,9 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
     if (pairData && pairData.token0 && pairData.token1) {
       const liquidity = formattedNum(pairData.reserveUSD, true);
       const volume = formattedNum(pairData.oneDayVolumeUSD, true);
+      const feeRate = getFeeRate(pairData);
       const apy = formattedPercent(
-        (pairData.oneDayVolumeUSD * 0.0025 * 365 * 100) / pairData.reserveUSD
+        (pairData.oneDayVolumeUSD * feeRate * 365 * 100) / pairData.reserveUSD
       );
       return (
         <DashGrid
@@ -210,7 +211,7 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
           )}
           {!below1080 && (
             <DataText area="fees">
-              {formattedNum(pairData.oneDayVolumeUSD * 0.0025, true)}
+              {formattedNum(pairData.oneDayVolumeUSD * feeRate, true)}
             </DataText>
           )}
           {!below1080 && <DataText area="apy">{apy}</DataText>}
@@ -227,12 +228,16 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10 }) {
       .sort((addressA, addressB) => {
         const pairA = pairs[addressA];
         const pairB = pairs[addressB];
+
+        const feeRateA = getFeeRate(pairA);
+        const feeRateB = getFeeRate(pairB);
+
         if (sortedColumn === SORT_FIELD.APY) {
           const apy0 =
-            parseFloat(pairA.oneDayVolumeUSD * 0.0025 * 356 * 100) /
+            parseFloat(pairA.oneDayVolumeUSD * feeRateA * 356 * 100) /
             parseFloat(pairA.reserveUSD);
           const apy1 =
-            parseFloat(pairB.oneDayVolumeUSD * 0.0025 * 356 * 100) /
+            parseFloat(pairB.oneDayVolumeUSD * feeRateB * 356 * 100) /
             parseFloat(pairB.reserveUSD);
           return apy0 > apy1
             ? (sortDirection ? -1 : 1) * 1

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useUserTransactions, useUserPositions } from "../contexts/User";
 import TxnList from "../components/TxnList";
 import Panel from "../components/Panel";
-import { formattedNum, getExplorerLink } from "../utils";
+import { formattedNum, getExplorerLink, getPaidFeeRateByTokenSymbols } from "../utils";
 import Row, { AutoRow, RowFixed, RowBetween } from "../components/Row";
 import { AutoColumn } from "../components/Column";
 import UserChart from "../components/UserChart";
@@ -110,6 +110,18 @@ function AccountPage({ account }) {
     return transactions?.swaps
       ? transactions?.swaps.reduce((total, swap) => {
           return total + parseFloat(swap.amountUSD);
+        }, 0)
+      : 0;
+  }, [transactions]);
+
+  let totalFeesPaidUSD = useMemo(() => {
+    return transactions?.swaps
+      ? transactions?.swaps.reduce((total, swap) => {
+          const symbol0 = swap.pair.token0.symbol;
+          const symbol1 = swap.pair.token1.symbol;
+          const paidFeeRate = getPaidFeeRateByTokenSymbols(symbol0, symbol1);
+
+          return total + parseFloat(swap.amountUSD) * paidFeeRate;
         }, 0)
       : 0;
   }, [transactions]);
@@ -397,8 +409,8 @@ function AccountPage({ account }) {
               </AutoColumn>
               <AutoColumn gap="8px">
                 <TYPE.header fontSize={24}>
-                  {totalSwappedUSD
-                    ? formattedNum(totalSwappedUSD * 0.0025, true)
+                  {totalFeesPaidUSD
+                    ? formattedNum(totalFeesPaidUSD, true)
                     : "-"}
                 </TYPE.header>
                 <TYPE.main>Total Fees Paid</TYPE.main>

--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -3,7 +3,11 @@ import styled from "styled-components";
 import { useUserTransactions, useUserPositions } from "../contexts/User";
 import TxnList from "../components/TxnList";
 import Panel from "../components/Panel";
-import { formattedNum, getExplorerLink, getPaidFeeRateByTokenSymbols } from "../utils";
+import {
+  formattedNum,
+  getExplorerLink,
+  getPaidFeeRateByTokenSymbols,
+} from "../utils";
 import Row, { AutoRow, RowFixed, RowBetween } from "../components/Row";
 import { AutoColumn } from "../components/Column";
 import UserChart from "../components/UserChart";
@@ -119,12 +123,16 @@ function AccountPage({ account }) {
       ? transactions?.swaps.reduce((total, swap) => {
           const symbol0 = swap.pair.token0.symbol;
           const symbol1 = swap.pair.token1.symbol;
-          const paidFeeRate = getPaidFeeRateByTokenSymbols(symbol0, symbol1);
+          const paidFeeRate = getPaidFeeRateByTokenSymbols(
+            symbol0,
+            symbol1,
+            selectedNetwork
+          );
 
           return total + parseFloat(swap.amountUSD) * paidFeeRate;
         }, 0)
       : 0;
-  }, [transactions]);
+  }, [transactions, selectedNetwork]);
 
   // if any position has token from fee warning list, show warning
   const [showWarning, setShowWarning] = useState(false);

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -19,6 +19,7 @@ import {
   getExplorerLink,
   getPoolLink,
   getSwapLink,
+  getFeeRate
 } from "../utils";
 import { useColor } from "../hooks";
 import { usePairData, usePairTransactions } from "../contexts/PairData";
@@ -165,12 +166,14 @@ function PairPage({ pairAddress, history }) {
     !usingUtVolume ? volumeChangeUSD : volumeChangeUntracked
   );
 
+  const feeRate = getFeeRate({ token0, token1 });
+
   // get fees	  // get fees
   const fees =
     oneDayVolumeUSD || oneDayVolumeUSD === 0
       ? usingUtVolume
-        ? formattedNum(oneDayVolumeUntracked * 0.0025, true)
-        : formattedNum(oneDayVolumeUSD * 0.0025, true)
+        ? formattedNum(oneDayVolumeUntracked * feeRate, true)
+        : formattedNum(oneDayVolumeUSD * feeRate, true)
       : "-";
 
   // token data for usd

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -123,6 +123,7 @@ function PairPage({ pairAddress, history }) {
     volumeChangeUntracked,
     liquidityChangeUSD,
   } = usePairData(pairAddress);
+  const selectedNetwork = useSelectedNetwork();
 
   useEffect(() => {
     document.querySelector("body").scrollTo(0, 0);
@@ -166,7 +167,7 @@ function PairPage({ pairAddress, history }) {
     !usingUtVolume ? volumeChangeUSD : volumeChangeUntracked
   );
 
-  const feeRate = getFeeRate({ token0, token1 });
+  const feeRate = getFeeRate({ token0, token1 }, selectedNetwork);
 
   // get fees	  // get fees
   const fees =
@@ -196,7 +197,6 @@ function PairPage({ pairAddress, history }) {
         )
       : "";
 
-  const selectedNetwork = useSelectedNetwork();
   const nativeCurrency = useNativeCurrencySymbol();
   const nativeCurrencyWrapper = useNativeCurrencyWrapper();
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -601,9 +601,9 @@ export function isEquivalent(a, b) {
 
 const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
 
-export function getFeeRate(pairData) {
-  return getAddress(pairData.token0.id) === wethContract ||
-  getAddress(pairData.token1.id) === wethContract
+export function getFeeRate({ token0, token1 }) {
+  return getAddress(token0.id) === wethContract ||
+  getAddress(token1.id) === wethContract
     ? 0.00125
     : 0.0025;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -599,16 +599,17 @@ export function isEquivalent(a, b) {
   return true;
 }
 
-const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
+const wethAddress = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
 
 export function getFeeRate({ token0, token1 }, selectedNetwork) {
-  if (!token0 || !token1) return 0.0025;
-  if (selectedNetwork !== "MATIC") return 0.0025;
-
-  return getAddress(token0.id) === wethContract ||
-  getAddress(token1.id) === wethContract
-    ? 0.00125
-    : 0.0025;
+  let feeRate = 0.0025;
+  if (!token0 || !token1) return feeRate;
+  if (selectedNetwork !== "MATIC") return feeRate;
+  if(getAddress(token0.id) === wethAddress || getAddress(token1.id) === wethAddress) {
+     feeRate = 0.00125;
+  }
+  
+  return feeRate;
 }
 
 export function getPaidFeeRateByTokenSymbols(token0Symbol, token1Symbol, selectedNetwork) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,6 +13,7 @@ import {
   ChainId,
 } from "../constants";
 import Numeral from "numeral";
+import { getAddress } from "ethers/utils";
 
 // format libraries
 const Decimal = toFormat(_Decimal);
@@ -596,4 +597,13 @@ export function isEquivalent(a, b) {
     }
   }
   return true;
+}
+
+const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
+
+export function getFeeRate(pairData) {
+  return getAddress(pairData.token0.id) === wethContract ||
+  getAddress(pairData.token1.id) === wethContract
+    ? 0.00125
+    : 0.0025;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -613,8 +613,11 @@ export function getFeeRate({ token0, token1 }, selectedNetwork) {
 }
 
 export function getPaidFeeRateByTokenSymbols(token0Symbol, token1Symbol, selectedNetwork) {
-  if (selectedNetwork !== "MATIC") return 0.003;
-  return token0Symbol === "WETH" || token1Symbol === "WETH"
-    ? 0.0015
-    : 0.003;
+  let feeRate = 0.003;
+  if (selectedNetwork !== "MATIC") return feeRate;
+  if (token0Symbol === "WETH" || token1Symbol === "WETH") {
+      feeRate = 0.0015;
+   }
+   
+  return feeRate;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -602,8 +602,16 @@ export function isEquivalent(a, b) {
 const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
 
 export function getFeeRate({ token0, token1 }) {
+  if (!token0 || !token1) return 0.0025;
+
   return getAddress(token0.id) === wethContract ||
   getAddress(token1.id) === wethContract
     ? 0.00125
     : 0.0025;
+}
+
+export function getPaidFeeRateByTokenSymbols(token0Symbol, token1Symbol) {
+  return token0Symbol === "WETH" || token1Symbol === "WETH"
+    ? 0.0015
+    : 0.003;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -601,8 +601,9 @@ export function isEquivalent(a, b) {
 
 const wethContract = getAddress("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619");
 
-export function getFeeRate({ token0, token1 }) {
+export function getFeeRate({ token0, token1 }, selectedNetwork) {
   if (!token0 || !token1) return 0.0025;
+  if (selectedNetwork !== "MATIC") return 0.0025;
 
   return getAddress(token0.id) === wethContract ||
   getAddress(token1.id) === wethContract
@@ -610,7 +611,8 @@ export function getFeeRate({ token0, token1 }) {
     : 0.0025;
 }
 
-export function getPaidFeeRateByTokenSymbols(token0Symbol, token1Symbol) {
+export function getPaidFeeRateByTokenSymbols(token0Symbol, token1Symbol, selectedNetwork) {
+  if (selectedNetwork !== "MATIC") return 0.003;
   return token0Symbol === "WETH" || token1Symbol === "WETH"
     ? 0.0015
     : 0.003;


### PR DESCRIPTION
Fixed the fee rates from 0.25% to 0.125% (0.30% -> 0.15%) for pairs containing wETH on:
- Global exchange stats
- Pair list
- Pair page
- Account page

### Refs:

#### Global exchange stats
![image](https://user-images.githubusercontent.com/22449631/124364240-8e510e00-dc16-11eb-8185-0773739e017f.png)

#### Pair list
![image](https://user-images.githubusercontent.com/22449631/124364267-ba6c8f00-dc16-11eb-81e7-6fc7703f2d98.png)

#### Pair page
![image](https://user-images.githubusercontent.com/22449631/124364280-d53f0380-dc16-11eb-8fd3-bf315fe3f04a.png)

#### Accounts page
![image](https://user-images.githubusercontent.com/22449631/124364216-5e096f80-dc16-11eb-9b96-46f4a1986279.png)
