### PR TITLE
Bright token volume stats hotfix

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -720,7 +720,7 @@ export const PAIRS_BULK = gql`
   query pairs($allPairs: [Bytes]!) {
     pairs(
       where: { id_in: $allPairs }
-      orderBy: trackedReserveNativeCurrency
+      orderBy: reserveNativeCurrency
       orderDirection: desc
     ) {
       ...PairFields

--- a/src/contexts/PairData.js
+++ b/src/contexts/PairData.js
@@ -354,11 +354,8 @@ function parseData(
     data.oneWeekVolumeUSD = oneWeekVolumeUntracked;
     data.volumeChangeUSD = volumeChangeUntracked;
     data.trackedReserveUSD =
-      data.untrackedReserveNativeCurrency * nativeCurrencyPrice;
-      
-      
+      data.untrackedReserveNativeCurrency * nativeCurrencyPrice;            
   }
-
 
   // format if pair hasnt existed for a day or a week
   if (!oneDayData && data && data.createdAtBlockNumber > oneDayBlock) {
@@ -370,7 +367,6 @@ function parseData(
   if (!oneWeekData && data) {
     data.oneWeekVolumeUSD = parseFloat(data.volumeUSD);
   }
-
     
   // format incorrect names
   updateNameData(data);

--- a/src/contexts/PairData.js
+++ b/src/contexts/PairData.js
@@ -220,6 +220,7 @@ async function getBulkPairData(
   pairList,
   nativeCurrencyPrice
 ) {
+
   const [t1, t2, tWeek] = getTimestampsForChanges();
   let [
     { number: b1 },
@@ -328,6 +329,10 @@ function parseData(
     oneWeekData ? data?.volumeUSD - oneWeekData?.volumeUSD : data.volumeUSD
   );
 
+  const oneWeekVolumeUntracked = parseFloat(
+    oneWeekData ? data?.untrackedVolumeUSD - oneWeekData?.untrackedVolumeUSD : data.untrackedVolumeUSD
+  );
+
   // set volume properties
   data.oneDayVolumeUSD = parseFloat(oneDayVolumeUSD);
   data.oneWeekVolumeUSD = oneWeekVolumeUSD;
@@ -343,6 +348,18 @@ function parseData(
     oneDayData?.reserveUSD
   );
 
+  // adjustments for  HNY-BRIGHT pair
+  if (data.id === "0x0907239acfe1d0cfc7f960fc7651e946bb34a7b0") {
+    data.oneDayVolumeUSD = parseFloat(oneDayVolumeUntracked);
+    data.oneWeekVolumeUSD = oneWeekVolumeUntracked;
+    data.volumeChangeUSD = volumeChangeUntracked;
+    data.trackedReserveUSD =
+      data.untrackedReserveNativeCurrency * nativeCurrencyPrice;
+      
+      
+  }
+
+
   // format if pair hasnt existed for a day or a week
   if (!oneDayData && data && data.createdAtBlockNumber > oneDayBlock) {
     data.oneDayVolumeUSD = parseFloat(data.volumeUSD);
@@ -354,6 +371,7 @@ function parseData(
     data.oneWeekVolumeUSD = parseFloat(data.volumeUSD);
   }
 
+    
   // format incorrect names
   updateNameData(data);
 
@@ -549,10 +567,13 @@ export function Updater() {
       });
 
       // format as array of addresses
-      const formattedPairs = pairs.map((pair) => {
+      let formattedPairs = pairs.map((pair) => {
         return pair.id;
       });
-
+        
+      // manually add BRIGHT-HNY pair
+      formattedPairs.push("0x0907239acfe1d0cfc7f960fc7651e946bb34a7b0")        
+        
       // get data for every pair in list
       let topPairs = await getBulkPairData(
         client,

--- a/src/contexts/PairData.js
+++ b/src/contexts/PairData.js
@@ -220,7 +220,6 @@ async function getBulkPairData(
   pairList,
   nativeCurrencyPrice
 ) {
-
   const [t1, t2, tWeek] = getTimestampsForChanges();
   let [
     { number: b1 },

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -285,11 +285,21 @@ const getTopTokens = async (
           }
 
           // calculate percentage changes and daily changes
-          const [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
+          let [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
             data.tradeVolumeUSD,
             oneDayHistory?.tradeVolumeUSD ?? 0,
             twoDayHistory?.tradeVolumeUSD ?? 0
           );
+
+          // check if token id is bright token id
+          if (token.id ===  "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e") {
+           [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
+             data.untrackedVolumeUSD,
+             oneDayHistory?.untrackedVolumeUSD ?? 0,
+              twoDayHistory?.untrackedVolumeUSD ?? 0
+            );    
+          }
+
           const [oneDayTxns, txnChange] = get2DayPercentChange(
             data.txCount,
             oneDayHistory?.txCount ?? 0,

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -445,9 +445,6 @@ const getTokenData = async (
         twoDayData?.tradeVolumeUSD ?? 0
     );
 
-
-    console.log("address")
-    console.log(address)
     //check if address is bright token
     if (address === "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e") {
       [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -429,12 +429,24 @@ const getTokenData = async (
     }
 
     // calculate percentage changes and daily changes
-    const [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
-      data?.tradeVolumeUSD,
-      oneDayData?.tradeVolumeUSD ?? 0,
-      twoDayData?.tradeVolumeUSD ?? 0
+    let [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
+        data?.tradeVolumeUSD,
+        oneDayData?.tradeVolumeUSD ?? 0,
+        twoDayData?.tradeVolumeUSD ?? 0
     );
 
+
+    console.log("address")
+    console.log(address)
+    //check if address is bright token
+    if (address === "0x83ff60e2f93f8edd0637ef669c69d5fb4f64ca8e") {
+      [oneDayVolumeUSD, volumeChangeUSD] = get2DayPercentChange(
+        data?.untrackedVolumeUSD,
+        oneDayData?.untrackedVolumeUSD ?? 0,
+        twoDayData?.untrackedVolumeUSD ?? 0
+      );
+    }
+    
     // calculate percentage changes and daily changes
     const [oneDayVolumeUT, volumeChangeUT] = get2DayPercentChange(
       data?.untrackedVolumeUSD,


### PR DESCRIPTION
> Bright had by far the most volume of any token on honeyswap after launch, but it wasn't showing.  Also Bright/HNY was the top pair for two days, but didn't show on the list at all.
> -- Adam

See discussion [here](https://discord.com/channels/698287700834517064/837806290008539148/889507917018042460) for context.

We can revert once subgraph has finished redeploying (according to @crisog , this may take a few weeks) 